### PR TITLE
rpi kernel: PREMIRROR git.yoctoproject.org -> github.com/yoctoproject

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -3,3 +3,14 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI += "file://enable-overlayfs.cfg"
 
 KERNEL_FEATURES:append = " features/overlayfs/overlayfs.scc"
+
+# Mirror yocto-kernel-cache (and other yoctoproject.org repos) via GitHub.
+# git.yoctoproject.org has had repeated outages in 2025 (cgit/DDoS) that
+# fail-stop kernel do_fetch with:
+#   "No up to date source found: clone directory not available or not up
+#    to date; shallow clone not enabled"
+# The official mirror at github.com/yoctoproject/<repo> tracks upstream
+# and is reachable from hosted ADO agents.
+PREMIRRORS:prepend = "\
+    git://git\\.yoctoproject\\.org/(.+) git://github.com/yoctoproject/\\1;protocol=https \n\
+"


### PR DESCRIPTION
## Why

`linux-raspberrypi_6.6.bb` fetches `yocto-kernel-cache` from `git://git.yoctoproject.org`. That host has had repeated outages in 2025 (cgit instability + DDoS mitigation) that fail-stop kernel `do_fetch` in our pipelines with:

```n"No up to date source found: clone directory not available or not up to date; shallow clone not enabled"
```n
## What

Adds a `PREMIRRORS:prepend` regex rewrite in `recipes-kernel/linux/linux-raspberrypi_%.bbappend` so any `git://git.yoctoproject.org/<repo>` URL is fetched from `git://github.com/yoctoproject/<repo>;protocol=https` instead.

- Regex form covers `yocto-kernel-cache` plus any future yoctoproject.org sources without per-recipe edits.
- SRCREVs unchanged → build output bit-identical.

## Coverage

Legacy normal RPi build (`IotHubDeviceUpdateYocto@main` -> `meta-raspberrypi-adu@feature/vnext-delta`). Sibling fix has been pushed to `meta-azure-device-update-bsp@user/msft/nox-msft/new-yocto-poc` (commit `b8b3712`) to cover the kas pipelines.